### PR TITLE
Fix to work with Babel 7

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,9 +149,9 @@ export default function ({types: t, template}: PluginParams): Plugin {
       );
     }
     else {
-      return expression(`console.log(prefix, content)`)({
-        prefix: t.stringLiteral(prefix),
-        content: message.content
+      return expression(`console.log(PREFIX, CONTENT)`)({
+        PREFIX: t.stringLiteral(prefix),
+        CONTENT: message.content
       });
     }
   }


### PR DESCRIPTION
Babel 7 updated the `template()` API, and now uses a [default pattern](/babel/babel/tree/master/packages/babel-template#placeholderpattern) `/^[_$A-Z0-9]+$/` for placeholder variables. This changes the `defaultLog` placeholders from `prefix, content` to `PREFIX, CONTENT` to match the pattern. Without this patch, using babel-plugin-trace in Babel 7 will result in an `Unknown substitution "prefix" given` error.

In case this package is no longer getting updated, I've pushed a version including the compiled `lib/index.js` to my fork. It's installable like this:
```
npm install --save-dev eemeli/babel-plugin-trace#babel7-build
```