### PR TITLE
Add macro.js + refactor "strip" API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ async function authenticate (username, password) {
     return false;
   }
   else if (!user.checkPassword(password)) {
-    log: 'invalid password';
+    log: ({ password: 'invalid' })
     return false;
   }
   else if (!user.isActive) {
@@ -91,6 +91,7 @@ As an alternative to use as a plugin, `babel-plugin-trace/macro` is provided for
 import initTrace from 'babel-plugin-trace/macro'
 initTrace()
 log: 'This is', { a: 'message' }
+warn: ({ this: 'a warning' }) // parentheses are required if the first value is an { object }
 ```
 
 To customise the logging labels, import them as named imports of the macro (the default import is still required, as the labels don't really match the imported variable bindings):
@@ -99,14 +100,10 @@ To customise the logging labels, import them as named imports of the macro (the 
 import initTrace, { log, announce } from 'babel-plugin-trace/macro'
 initTrace()
 announce: 'This is', { an: 'announcement' }
+warn: 'This is not logged as a warning'
 ```
 
-Unfortunately the `initTrace` call is required until [kentcdodds/babel-plugin-macros#65](https://github.com/kentcdodds/babel-plugin-macros/pull/65) is merged, after which the API simplifies to:
-
-```js
-import 'babel-plugin-trace/macro'
-log: 'This is', { another: 'message' }
-```
+A source reference to the default export [is required](https://github.com/kentcdodds/babel-plugin-macros/pull/65) to trigger the macro; it will be removed during transpilation.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Babel Plugin: Trace
 
-This is a [Babel](https://babeljs.io/) plugin which adds a straightforward, declarative syntax for adding debug logging to JavaScript applications.
+This is a [Babel](https://babeljs.io/) plugin & macro which adds a straightforward, declarative syntax for adding debug logging to JavaScript applications.
 
 [![Build Status](https://travis-ci.org/codemix/babel-plugin-trace.svg)](https://travis-ci.org/codemix/babel-plugin-trace)
 
-# What?
+## What?
 
 It's common to insert `console.log()` statements to help keep track of the internal state of functions when writing tricky pieces of code. During development this is very useful, but it creates a lot of noise in the console, and when development of that particular piece of code is complete, the developer is likely to delete the `console.log()` calls. If we're lucky, they might leave comments in their place.
 
 This is a tragedy - that logging information is extremely useful, not only is it helpful when fixing bugs, it's a great assistance for new developers (including yourself, 6 months from now) when getting to know a codebase.
 
-This plugin repurposes JavaScript LabeledStatements like `log:` and `trace:` to provide a logging / tracing syntax which can be selectively enabled or disabled at the folder, file, or function level at build time. Normally, these labels are only used as targets for labeled `break` and `continue` statements.
+This plugin repurposes JavaScript [LabeledStatements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label) like `log:` and `trace:` to provide a logging / tracing syntax which can be selectively enabled or disabled at the folder, file, or function level at build time. Normally, these labels are only used as targets for labeled `break` and `continue` statements.
 
 When disabled in production the logging statements are completely dropped out, incurring no overhead. The syntax looks like this:
 
@@ -18,21 +18,21 @@ When disabled in production the logging statements are completely dropped out, i
 // login.js
 
 async function authenticate (username, password) {
-  trace: 'authenticating user', username;
+  log: 'authenticating user', username;
   const user = await db.select().from('users').where({username: username});
   if (!user) {
-    trace: 'no such user';
+    log: 'no such user';
     return false;
   }
   else if (!user.checkPassword(password)) {
-    trace: 'invalid password';
+    log: 'invalid password';
     return false;
   }
   else if (!user.isActive) {
-    trace: 'user is not active';
+    log: 'user is not active';
     return false;
   }
-  trace: 'logging user', username, 'into the site';
+  log: 'logging user', username, 'into the site';
   return true;
 }
 ```
@@ -48,31 +48,33 @@ login:authenticate: authenticating user Alice
 login:authenticate: logging user Alice into the site
 ```
 
-As well as `trace:`, you can also use `log:` and `warn:`, or specify your own using the `aliases` plugin option.
+As well as `log:`, you can also use `trace:` and `warn:`, or specify your own using the `aliases` plugin option. By default all `trace:` logs will be stripped (unless specifically enabled) and `warn:` will use `console.warn` rather than `console.log`.
 
-
-# Installation & Configuration
+## Installation
 
 Install via [npm](https://npmjs.org/package/babel-plugin-trace).
-```sh
+```
 npm install --save-dev babel-plugin-trace
 ```
-Then, in your babel configuration (usually in your `.babelrc` file), add `"trace"` to your list of plugins:
+
+## Plugin Configuration
+
+In your Babel configuration, add `"trace"` to your list of plugins. The default configuration will strip all logging from production builds, as well as trace logging from development and test environment, corresponding to this configuration:
 ```json
 {
   "plugins": [
     ["trace", {
-      "env": {
-        "production": { "strip": true }
+      "strip": {
+        "log": { "production": true },
+        "trace": true,
+        "warn": { "production": true }
       }
     }]
   ]
 }
 ```
 
-The above example configuration will remove all tracing when `NODE_ENV=production`.
-
-Alternatively, you may wish to disable all tracing by default, enabling it only for certain files or functions using environment variables:
+`"strip"` may also take a `true` value to disable all logging by default. In this case you can still enable it for certain files or functions using environment variables:
 ```json
 {
   "plugins": [
@@ -81,8 +83,32 @@ Alternatively, you may wish to disable all tracing by default, enabling it only 
 }
 ```
 
+## Macro Configuration
 
-# Environment Variables
+As an alternative to use as a plugin, `babel-plugin-trace/macro` is provided for use together with [babel-plugin-macros](https://github.com/kentcdodds/babel-plugin-macros). This is relevant in particular if you're working with a [create-react-app](https://github.com/facebook/create-react-app) project, as that does not otherwise allow for Babel plugins to be used. With macro use, you'll need to import the macro in every file where you'd like to enable logging:
+
+```js
+import initTrace from 'babel-plugin-trace/macro'
+initTrace()
+log: 'This is', { a: 'message' }
+```
+
+To customise the logging labels, import them as named imports of the macro (the default import is still required, as the labels don't really match the imported variable bindings):
+
+```js
+import initTrace, { log, announce } from 'babel-plugin-trace/macro'
+initTrace()
+announce: 'This is', { an: 'announcement' }
+```
+
+Unfortunately the `initTrace` call is required until [kentcdodds/babel-plugin-macros#65](https://github.com/kentcdodds/babel-plugin-macros/pull/65) is merged, after which the API simplifies to:
+
+```js
+import 'babel-plugin-trace/macro'
+log: 'This is', { another: 'message' }
+```
+
+## Environment Variables
 
 ### `TRACE_LEVEL` - Enable only specific logging levels
 Log only `warn` statements.
@@ -117,8 +143,7 @@ Enable logging for any function in a class called `User`.
 TRACE_CONTEXT=:User: babel -d ./lib ./src
 ```
 
-
-# License
+## License
 
 Published by [codemix](http://codemix.com/) under a permissive MIT License, see [LICENSE.md](./LICENSE.md).
 

--- a/macro.js
+++ b/macro.js
@@ -1,0 +1,31 @@
+const { createMacro } = require('babel-plugin-macros');
+const { getLogFunction, handleLabeledStatement } = require('.');
+
+function macro({
+  babel,
+  config: {
+    aliases,
+    strip,
+    warningLabels = ['warn']
+  } = {},
+  references,
+  state
+}) {
+  const refNames = Object.keys(references).filter(ref => ref !== 'default');
+  if (refNames.length > 0) {
+    aliases = refNames.reduce((map, key) => {
+      const logLevel = warningLabels && warningLabels.includes(key) ? 'warn' : 'log';
+      map[key] = getLogFunction(babel, logLevel);
+      return map;
+    }, {});
+  }
+  if (references.default) references.default.forEach(({ parentPath }) => parentPath.remove());
+  const opts = { aliases, strip };
+  state.file.path.traverse({
+    LabeledStatement (path) {
+      handleLabeledStatement(babel, path, opts);
+    }
+  });
+}
+
+module.exports = createMacro(macro, { configName: 'trace' });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "keywords": [
     "babel",
     "babel-plugin",
+    "babel-plugin-macros",
     "logging",
     "trace",
     "tracing",
@@ -47,5 +48,8 @@
     "babel-preset-stage-1": "^6.1.0",
     "mocha": "~2.2.4",
     "should": "^6.0.1"
+  },
+  "dependencies": {
+    "babel-plugin-macros": "^2.2.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -158,6 +158,13 @@ function normalizeOpts (babel: PluginParams, opts: PluginOptions): PluginOptions
       }
     });
   }
+  if (opts.strip === undefined) {
+    opts.strip = {
+      log: { production: true },
+      trace: true,
+      warn: { production: true }
+    };
+  }
   opts[$normalized] = true;
   return opts;
 }

--- a/test/fixtures/classes.js
+++ b/test/fixtures/classes.js
@@ -1,10 +1,10 @@
 class Thing {
   foo () {
-    trace: "foo";
+    log: "foo";
     if (true) {
-      trace: "bar";
+      log: "bar";
       if (true) {
-        trace: "qux";
+        log: "qux";
         (() => {
           warn: "nested";
         })();

--- a/test/fixtures/if-statement.js
+++ b/test/fixtures/if-statement.js
@@ -1,9 +1,9 @@
 export default function demo () {
-  trace: "hello world";
+  log: "hello world";
   if (Math.random() > 0.5) {
-    trace: "Got result.";
+    log: "Got result.";
   }
   else {
-    trace: "Got result."
+    log: "Got result."
   }
 }

--- a/test/fixtures/multiple.js
+++ b/test/fixtures/multiple.js
@@ -1,5 +1,5 @@
 export default function demo () {
-  trace: {
+  log: {
     "hello world";
     "foo bar";
   }

--- a/test/fixtures/sequence.js
+++ b/test/fixtures/sequence.js
@@ -1,3 +1,3 @@
 export default function demo () {
-  trace: "hello world", "foo", "bar";
+  log: "hello world", "foo", "bar";
 }

--- a/test/fixtures/simple.js
+++ b/test/fixtures/simple.js
@@ -1,3 +1,3 @@
 export default function demo () {
-  trace: "hello world";
+  log: "hello world";
 }


### PR DESCRIPTION
I started fiddling with this to make it work in create-react-app projects, which should in its v2 release bake in [support](/facebook/create-react-app/pull/3675) for [babel-plugin-macros](/kentcdodds/babel-plugin-macros). In fact that's already available using the `next` tag of `react-scripts`, but not yet documented. The macro API is a little clumsy still, but I've submitted a PR to improve it: kentcdodds/babel-plugin-macros#65.

While at that, I fixed a few bugs and came to think that the `"strip"` option API is a bit clumsy, esp. as Babel 7 [has been considering](/babel/babel/issues/5276) deprecating the env configuration of options. So I changed its semantics a bit.

I also think that the default `strip` value should be more opinionated to make `trace`, `log` and `warn` really mean different things. So I'm suggesting to by default always strip `trace`, and to strip everything in production + use `console.warn` for warnings.

Put together, all of that sounds like enough for a semver major version bump, hence this PR. It's not really ready to merge in though, as we should wait at least to see if the babel-plugin-macros change is accepted & published.